### PR TITLE
Fix missing validation in hints endpoint

### DIFF
--- a/algo-backend/server.js
+++ b/algo-backend/server.js
@@ -48,6 +48,11 @@ app.post('/api/hints', async (req, res) => {
             problemTitle: req.body.problemInfo?.title
         });
 
+        // Validate input
+        if (!req.body.message) {
+            return res.status(400).json({ error: 'Message is required' });
+        }
+
         if (!process.env.GEMINI_API_KEY) {
             throw new Error('GEMINI_API_KEY is not set in environment variables');
         }


### PR DESCRIPTION
## Summary
- add message field validation in `/api/hints`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c55b960832fadfa657bb67164cd