### PR TITLE
Fix redis test cleanup

### DIFF
--- a/algo-backend/__tests__/cache.test.js
+++ b/algo-backend/__tests__/cache.test.js
@@ -15,4 +15,13 @@ describe('Redis Cache Service', () => {
     const cached = await cache.getCachedHint(testKey);
     expect(cached).toBeNull();
   });
-}); 
+
+  afterAll(async () => {
+    // Close the Redis connection to prevent open handles
+    if (cache.redis && typeof cache.redis.quit === 'function') {
+      await cache.redis.quit();
+    } else if (cache.redis && typeof cache.redis.disconnect === 'function') {
+      cache.redis.disconnect();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- close Redis connection after running cache tests

## Testing
- `bash node_modules/.bin/jest` *(fails: Cannot find module 'ioredis')*
- `npm test` in project root *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6fb40b4c832fbadf81944af71dc9