### PR TITLE
Add message validation to hints API

### DIFF
--- a/algo-backend/__tests__/server.test.js
+++ b/algo-backend/__tests__/server.test.js
@@ -22,5 +22,6 @@ describe('Server Endpoints', () => {
   it('should return 400 for hints endpoint without message', async () => {
     const res = await request(app).post('/api/hints');
     expect(res.statusCode).toEqual(400);
+    expect(res.body).toHaveProperty('error', 'Message is required');
   });
 }); 

--- a/algo-backend/server.js
+++ b/algo-backend/server.js
@@ -41,17 +41,16 @@ app.get('/', (req, res) => {
 
 // Main endpoint for hints
 app.post('/api/hints', async (req, res) => {
+    if (!req.body?.message) {
+        return res.status(400).json({ error: 'Message is required' });
+    }
+
     try {
         console.log('Received request:', {
             message: req.body.message,
             hasProblemInfo: !!req.body.problemInfo,
             problemTitle: req.body.problemInfo?.title
         });
-
-        // Validate input
-        if (!req.body.message) {
-            return res.status(400).json({ error: 'Message is required' });
-        }
 
         if (!process.env.GEMINI_API_KEY) {
             throw new Error('GEMINI_API_KEY is not set in environment variables');


### PR DESCRIPTION
## Summary
- validate incoming requests to /api/hints and return 400 if message is missing
- update server test to check for proper error message

## Testing
- `npm test --silent` *(fails: jest not found)*
- `cd algo-backend && npm test --silent` *(fails: Cannot find module 'ioredis')*

------
https://chatgpt.com/codex/tasks/task_e_683f6f9ce5e4832fa2218276d356070e